### PR TITLE
BUGFIX: define ViewsInterface in Twig Render Example

### DIFF
--- a/docs/en/views/twig.md
+++ b/docs/en/views/twig.md
@@ -49,9 +49,12 @@ Hello, {{ name }}!
 You can use this view without an extension in your controllers:
 
 ```php
-public function index(): string
+use Spiral\Views\ViewsInterface;
+
+// ...
+public function index(ViewsInterface $views): string
 {
-    return $this->views->render('filename', ['name' => 'User']);
+    return $views->render('filename', ['name' => 'User']);
 }
 ```
 


### PR DESCRIPTION
Its also defined here: https://spiral.dev/docs/views-render/3.3/en

Otherwise it could lead to confusion, because:

```php
return $this->views->render('filename', ['name' => 'User']);
```
doesent work.